### PR TITLE
Export documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,8 @@ It's used to export only the documents; 'include_docs' is needed; if it's false
 this parameter has no effect.</dd>
 <dt>export_keys</dt><dd>if 'output_format' is present this parameter will
 indicate the document properties that will be exported.</dd>
+<dt>csv_labels</dt><dd>if 'output_format=csv' this parameter indicates the
+first row with the column headers. Otherwise will be ignored.</dd>
 </dl>
 
 <i>All parameters except 'q' are optional.</i>

--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ this parameter has no effect.</dd>
 indicate the document properties that will be exported.</dd>
 <dt>csv_labels</dt><dd>if 'output_format=csv' this parameter indicates the
 first row with the column headers. Otherwise will be ignored.</dd>
+<dt>csv_delimiter</dt><dd>if 'output_format=csv' this parameter indicates the
+character used to separate the values.</dd>
 </dl>
 
 <i>All parameters except 'q' are optional.</i>

--- a/README.md
+++ b/README.md
@@ -439,6 +439,12 @@ The following parameters can be passed for more sophisticated searches;
 <dt>skip</dt><dd>the number of results to skip</dd>
 <dt>sort</dt><dd>the comma-separated fields to sort on. Prefix with / for ascending order and \ for descending order (ascending is the default if not specified). Type-specific sorting is also available by appending the type between angle brackets (e.g, sort=amount&lt;float&gt;). Supported types are 'float', 'double', 'int', 'long' and 'date'.</dd>
 <dt>stale=ok</dt><dd>If you set the <i>stale</i> option to <i>ok</i>, couchdb-lucene will not block if the index is not up to date and it will immediately return results. Therefore searches may be faster as Lucene caches important data (especially for sorting). A query without stale=ok will block and use the latest data committed to the index. Unlike CouchDBs stale=ok option for views, couchdb-lucene will trigger an index update unless one is already running.</dd>
+<dt>output_format</dt><dd>the expected output format for the documents export.
+Allowed values: <i>json</i>, <i>xml</i>, <i>csv</i>.
+It's used to export only the documents; 'include_docs' is needed; if it's false
+this parameter has no effect.</dd>
+<dt>export_keys</dt><dd>if 'output_format' is present this parameter will
+indicate the document properties that will be exported.</dd>
 </dl>
 
 <i>All parameters except 'q' are optional.</i>
@@ -502,6 +508,9 @@ The search result contains a number of fields at the top level, in addition to y
 <dt>skip</dt><dd>The number of initial matches that was skipped.</dd>
 <dt>total_rows</dt><dd>The total number of matches for this query.</dd>
 </dl>
+
+If the parameter 'output_format' is present; the results format will only
+contain the formatted and mapped <i>search results array</i>.
 
 <h2>The search results array</h2>
 

--- a/src/main/java/com/github/rnewson/couchdb/lucene/DatabaseIndexer.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/DatabaseIndexer.java
@@ -17,6 +17,8 @@
 package com.github.rnewson.couchdb.lucene;
 
 import com.github.rnewson.couchdb.lucene.couchdb.*;
+import com.github.rnewson.couchdb.lucene.output.Output;
+import com.github.rnewson.couchdb.lucene.output.OutputDispatcher;
 import com.github.rnewson.couchdb.lucene.util.*;
 import org.apache.commons.configuration.HierarchicalINIConfiguration;
 import org.apache.http.HttpEntity;
@@ -654,26 +656,14 @@ public final class DatabaseIndexer implements Runnable, ResponseHandler<Void> {
             state.returnSearcher(searcher);
         }
 
+
         resp.setHeader("ETag", etag);
         resp.setHeader("Cache-Control", "must-revalidate");
         ServletUtils.setResponseContentTypeAndEncoding(req, resp);
 
-        final Object json = result.length() > 1 ? result : result.getJSONObject(0);
-        final String callback = req.getParameter("callback");
-        final String body;
-        if (callback != null) {
-            body = String.format("%s(%s)", callback, json);
-        } else {
-            if (json instanceof JSONObject) {
-                final JSONObject obj = (JSONObject) json;
-                body = getBooleanParameter(req, "debug") ?
-                        obj.toString(2) : obj.toString();
-            } else {
-                final JSONArray arr = (JSONArray) json;
-                body = getBooleanParameter(req, "debug") ?
-                        arr.toString(2) : arr.toString();
-            }
-        }
+        // writes the output based on parameters
+        Output output = OutputDispatcher.getOutput(req);
+        String body = output.getBody(req, resp, result);
 
         final Writer writer = resp.getWriter();
         try {

--- a/src/main/java/com/github/rnewson/couchdb/lucene/DatabaseIndexer.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/DatabaseIndexer.java
@@ -17,7 +17,6 @@
 package com.github.rnewson.couchdb.lucene;
 
 import com.github.rnewson.couchdb.lucene.couchdb.*;
-import com.github.rnewson.couchdb.lucene.output.Output;
 import com.github.rnewson.couchdb.lucene.output.OutputDispatcher;
 import com.github.rnewson.couchdb.lucene.util.*;
 import org.apache.commons.configuration.HierarchicalINIConfiguration;
@@ -450,7 +449,6 @@ public final class DatabaseIndexer implements Runnable, ResponseHandler<Void> {
         }
 
 
-
         try {
             try {
                 final long changes_timeout = ini.getLong("lucene.changes_timeout", -1);
@@ -662,8 +660,7 @@ public final class DatabaseIndexer implements Runnable, ResponseHandler<Void> {
         ServletUtils.setResponseContentTypeAndEncoding(req, resp);
 
         // writes the output based on parameters
-        Output output = OutputDispatcher.getOutput(req);
-        String body = output.getBody(req, resp, result);
+        String body = OutputDispatcher.getOutput(req).getBody(req, resp, result);
 
         final Writer writer = resp.getWriter();
         try {
@@ -867,9 +864,9 @@ public final class DatabaseIndexer implements Runnable, ResponseHandler<Void> {
     private final List<String> blacklist() {
         Integer size = ini.getList("couchdb.blacklist", new ArrayList<String>()).size();
         List<String> blacklist = new ArrayList<String>(size);
-            for (Object o : ini.getList("couchdb.blacklist", new ArrayList<String>())) {
-                blacklist.add(String.valueOf(o));
-            }
+        for (Object o : ini.getList("couchdb.blacklist", new ArrayList<String>())) {
+            blacklist.add(String.valueOf(o));
+        }
         return blacklist;
     }
 }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/DefaultOutputImpl.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/DefaultOutputImpl.java
@@ -1,0 +1,47 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import com.github.rnewson.couchdb.lucene.util.ServletUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Default response
+ */
+public class DefaultOutputImpl implements OutputFactory {
+
+    @Override
+    public String getBody(HttpServletRequest req,
+                          HttpServletResponse resp,
+                          JSONArray docs,
+                          final String eTag,
+                          final boolean debug)
+            throws IOException, JSONException {
+
+        final Object json = docs.length() > 1 ? docs : docs.getJSONObject(0);
+        final String callback = req.getParameter("callback");
+        final String body;
+
+        resp.setHeader("ETag", eTag);
+        resp.setHeader("Cache-Control", "must-revalidate");
+        ServletUtils.setResponseContentTypeAndEncoding(req, resp);
+
+        if (callback != null) {
+            body = String.format("%s(%s)", callback, json);
+        } else {
+            if (json instanceof JSONObject) {
+                final JSONObject obj = (JSONObject) json;
+                body = debug ? obj.toString(2) : obj.toString();
+            } else {
+                final JSONArray arr = (JSONArray) json;
+                body = debug ? arr.toString(2) : arr.toString();
+            }
+        }
+
+        return body;
+    }
+}

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/DefaultOutputImpl.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/DefaultOutputImpl.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 /**
  * Default response
  */
-public class DefaultOutputImpl implements OutputFactory {
+public class DefaultOutputImpl implements Output {
 
     @Override
     public String getBody(HttpServletRequest req,

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/DefaultOutputImpl.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/DefaultOutputImpl.java
@@ -1,6 +1,5 @@
 package com.github.rnewson.couchdb.lucene.output;
 
-import com.github.rnewson.couchdb.lucene.util.ServletUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -14,31 +13,32 @@ import java.io.IOException;
  */
 public class DefaultOutputImpl implements Output {
 
+    private String callback;
+    private boolean debug;
+
+    public DefaultOutputImpl(String callback, boolean debug) {
+        this.callback = callback;
+        this.debug = debug;
+    }
+
     @Override
     public String getBody(HttpServletRequest req,
                           HttpServletResponse resp,
-                          JSONArray docs,
-                          final String eTag,
-                          final boolean debug)
+                          JSONArray docs)
             throws IOException, JSONException {
 
         final Object json = docs.length() > 1 ? docs : docs.getJSONObject(0);
-        final String callback = req.getParameter("callback");
         final String body;
 
-        resp.setHeader("ETag", eTag);
-        resp.setHeader("Cache-Control", "must-revalidate");
-        ServletUtils.setResponseContentTypeAndEncoding(req, resp);
-
-        if (callback != null) {
-            body = String.format("%s(%s)", callback, json);
+        if (this.callback != null) {
+            body = String.format("%s(%s)", this.callback, json);
         } else {
             if (json instanceof JSONObject) {
                 final JSONObject obj = (JSONObject) json;
-                body = debug ? obj.toString(2) : obj.toString();
+                body = this.debug ? obj.toString(2) : obj.toString();
             } else {
                 final JSONArray arr = (JSONArray) json;
-                body = debug ? arr.toString(2) : arr.toString();
+                body = this.debug ? arr.toString(2) : arr.toString();
             }
         }
 

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/DocumentsOutputImpl.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/DocumentsOutputImpl.java
@@ -19,17 +19,20 @@ public class DocumentsOutputImpl implements Output {
     private boolean debug;
     private String[] keys;
     private String labels;
+    private String delimiter;
 
     public DocumentsOutputImpl(String callback,
                                boolean debug,
                                OutputFormats format,
                                String[] keys,
-                               String labels) {
+                               String labels,
+                               String delimiter) {
         this.callback = callback;
         this.debug = debug;
         this.format = format;
         this.keys = keys;
         this.labels = labels;
+        this.delimiter = delimiter;
     }
 
     @Override
@@ -46,7 +49,8 @@ public class DocumentsOutputImpl implements Output {
             resp.setContentType(this.format.getContentType());
             return this.debug ?
                     json.toString(2) :
-                    this.format.transformDocs(json, this.keys, this.labels);
+                    this.format.transformDocs(json, this.keys,
+                            this.labels, this.delimiter);
         }
     }
 }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/DocumentsOutputImpl.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/DocumentsOutputImpl.java
@@ -18,15 +18,18 @@ public class DocumentsOutputImpl implements Output {
     private String callback;
     private boolean debug;
     private String[] keys;
+    private String labels;
 
     public DocumentsOutputImpl(String callback,
                                boolean debug,
                                OutputFormats format,
-                               String[] keys) {
+                               String[] keys,
+                               String labels) {
         this.callback = callback;
         this.debug = debug;
         this.format = format;
         this.keys = keys;
+        this.labels = labels;
     }
 
     @Override
@@ -43,7 +46,7 @@ public class DocumentsOutputImpl implements Output {
             resp.setContentType(this.format.getContentType());
             return this.debug ?
                     json.toString(2) :
-                    this.format.transformDocs(json, this.keys);
+                    this.format.transformDocs(json, this.keys, this.labels);
         }
     }
 }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/DocumentsOutputImpl.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/DocumentsOutputImpl.java
@@ -1,0 +1,49 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * JSON response
+ * <p/>
+ * Transforms the JSON documents in other JSON documents
+ */
+public class DocumentsOutputImpl implements Output {
+
+    private OutputFormats format;
+    private String callback;
+    private boolean debug;
+    private String[] keys;
+
+    public DocumentsOutputImpl(String callback,
+                               boolean debug,
+                               OutputFormats format,
+                               String[] keys) {
+        this.callback = callback;
+        this.debug = debug;
+        this.format = format;
+        this.keys = keys;
+    }
+
+    @Override
+    public String getBody(HttpServletRequest req,
+                          HttpServletResponse resp,
+                          JSONArray docs)
+            throws IOException, JSONException {
+
+        final JSONArray json = JSONUtils.getDocs(docs, this.keys);
+
+        if (this.callback != null) {
+            return String.format("%s(%s)", this.callback, json);
+        } else {
+            resp.setContentType(this.format.getContentType());
+            return this.debug ?
+                    json.toString(2) :
+                    this.format.transformDocs(json, this.keys);
+        }
+    }
+}

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/JSONUtils.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/JSONUtils.java
@@ -1,0 +1,393 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import org.apache.commons.lang.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+/**
+ * Common methods
+ */
+public class JSONUtils {
+
+    /**
+     * Extracts from the `rows` property in the array the property `doc`
+     * <p/>
+     * docs:
+     * [ { "rows" : [
+     * { "doc" : { "a" : 1, "b" : 1 } },
+     * { "doc" : { "a" : 2, "b" : 2 } }
+     * ] } ]
+     * keys:
+     * [ "a" ]
+     * <p/>
+     * Returns:
+     * [ { "a" : 1 }, { "a" : 2 } ]
+     *
+     * @param docs, the searched documents
+     * @param keys, the properties to use, if empty all
+     * @return the array of `doc` property included in the rows array
+     */
+    public static JSONArray getDocs(JSONArray docs, String[] keys)
+            throws JSONException {
+
+        JSONArray result = new JSONArray();
+
+        for (int i = 0; i < docs.length(); i++) {
+            JSONArray rows = docs.getJSONObject(i).getJSONArray("rows");
+            if (rows != null) {
+                for (int j = 0; j < rows.length(); j++) {
+                    JSONObject doc = rows.getJSONObject(j).getJSONObject("doc");
+                    if (doc != null) {
+                        result.put(map(doc, keys));
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Maps document to the given list of properties
+     * <p/>
+     * doc:
+     * { "a" : { "b" : 1, "c" : 2}, "d" : 4 }
+     * names:
+     * [ "a.b", "d" ]
+     * <p/>
+     * Returns:
+     * { "a" { "b" : 1 }, "d" : 4 }
+     *
+     * @param doc  the document to be mapped
+     * @param keys the list of names for the new document
+     * @return the mapped document or the original document if names is empty
+     * @throws JSONException
+     */
+    public static JSONObject map(JSONObject doc, String[] keys)
+            throws JSONException {
+        if (keys == null || keys.length == 0) {
+            // nothing to map
+            return doc;
+        }
+
+        JSONObject target = new JSONObject();
+        mapping(target, doc, keys);
+        return target;
+    }
+
+    /**
+     * Maps documents with the given list of properties
+     *
+     * @param docs the array of documents
+     * @param keys the list of names for the new documents
+     * @return the array with mapped documents
+     * @throws JSONException
+     */
+    public static JSONArray map(JSONArray docs, String[] keys)
+            throws JSONException {
+
+        if (keys == null || keys.length == 0) {
+            // nothing to map
+            return docs;
+        }
+
+        // create new array with mapped documents
+        JSONArray array = new JSONArray();
+        for (int i = 0; i < docs.length(); i++) {
+            array.put(map(docs.getJSONObject(i), keys));
+        }
+
+        return array;
+    }
+
+    /**
+     * Flat the JSON document (no nested properties)
+     * <p/>
+     * doc:
+     * { "a" : { "b" : 1 }, "c" : [ 1, 2, 3 ], "d" : 4 }
+     * keys:
+     * null
+     * <p/>
+     * Returns:
+     * { "a.b" : 1, "c.0" : 1, "c.1" : 2, "c.2" : 3, "d" : 4 }
+     *
+     * @param doc   the document to be flattened
+     * @param keys, the properties to use, if empty all
+     * @return the flattened document
+     * @throws JSONException
+     */
+    public static JSONObject flat(JSONObject doc, String[] keys)
+            throws JSONException {
+        JSONObject target = new JSONObject();
+        String[] allowedKeys;
+        if (keys == null) {
+            allowedKeys = new String[0];
+        } else {
+            allowedKeys = Arrays.copyOf(keys, keys.length);
+            Arrays.sort(allowedKeys);
+        }
+        flatting(target, doc, null, allowedKeys);
+        return target;
+    }
+
+    /**
+     * Flattens the array of JSON documents.
+     *
+     * @param array the array with the documents
+     * @param keys, the properties to use, if empty all
+     * @return an array with the flattened documents
+     * @throws JSONException if the arrays does not contain ALL JSON objects
+     */
+    public static JSONArray flat(JSONArray array, String[] keys)
+            throws JSONException {
+        JSONArray target = new JSONArray();
+        for (int i = 0; i < array.length(); i++) {
+            if (!(array.get(i) instanceof JSONObject)) {
+                throw new JSONException("Error flattening JSONArray.");
+            }
+            target.put(flat(array.getJSONObject(i), keys));
+        }
+        return target;
+    }
+
+    /**
+     * Get the value within a document
+     * <p/>
+     * doc:
+     * { "a" : { "b" : 1 } }
+     * key:
+     * "a.b"
+     * <p/>
+     * Returns:
+     * 1
+     * <p/>
+     * doc: { "c" : [ 1, 2, 3 ] }
+     * key: "c.1"
+     * Returns:
+     * 2
+     *
+     * @param doc the document in which search
+     * @param key the property to search
+     * @return the property value
+     * @throws JSONException
+     */
+    public static Object getNestedProperty(JSONObject doc,
+                                           String key)
+            throws JSONException {
+
+        return getNested(doc, key);
+    }
+
+    /**
+     * Set the value within a document
+     * <p/>
+     * doc: { "a" : { "b" : 1 } }
+     * key: "a.b"
+     * value: 2
+     * <p/>
+     * Result:
+     * doc: { "a" : { "b" : 2 } }
+     * <p/>
+     * doc: { "c" : [ 1, 2, 3 ] }
+     * key: "c.1"
+     * value: 9
+     * <p/>
+     * Result:
+     * doc: { "c" : [ 1, 9, 3 ] }
+     *
+     * @param doc   the document in which search
+     * @param key   the property to search
+     * @param value the value to assign
+     * @throws JSONException
+     */
+    public static void setNestedProperty(JSONObject doc,
+                                         String key,
+                                         Object value)
+            throws JSONException {
+
+        setNested(doc, key, value);
+    }
+
+
+    private static void mapping(JSONObject target,
+                                JSONObject doc,
+                                String[] keys)
+            throws JSONException {
+        for (String key : keys) {
+            setNested(target, key, getNested(doc, key));
+        }
+    }
+
+    private static void flatting(JSONObject target,
+                                 Object obj,
+                                 String prefix,
+                                 String[] allowedKeys)
+            throws JSONException {
+
+        if (obj instanceof JSONObject) {
+            JSONObject doc = (JSONObject) obj;
+
+            Iterator<?> keys = doc.keys();
+            while (keys.hasNext()) {
+                String key = (String) keys.next();
+
+                flatting(target,
+                        doc.get(key),
+                        getKey(prefix, key),
+                        allowedKeys);
+            }
+        } else if (obj instanceof JSONArray) {
+            // array
+            JSONArray array = (JSONArray) obj;
+            for (int i = 0; i < array.length(); i++) {
+                flatting(target,
+                        array.get(i),
+                        getKey(prefix, Integer.toString(i, 10)),
+                        allowedKeys);
+            }
+
+        } else {
+            // already flat
+            if (allowedKeys == null || allowedKeys.length == 0
+                    || Arrays.binarySearch(allowedKeys, prefix) != -1) {
+                target.putOpt(prefix, obj);
+            }
+        }
+    }
+
+    private static String getKey(String prefix, String key) {
+        if (prefix == null) {
+            return key;
+        } else {
+            return prefix + "." + key;
+        }
+    }
+
+    private static Object getNested(Object obj,
+                                    String key)
+            throws JSONException {
+
+        String[] parts = splitKey(key);
+
+        if (obj instanceof JSONObject) {
+            JSONObject doc = (JSONObject) obj;
+
+            if (StringUtils.isNumeric(parts[0])) {
+                // this is not an array, something is wrong
+                throw new JSONException("getNested: Unexpected int key");
+            }
+
+            if (parts[1].equals("")) {
+                return doc.opt(key);
+            } else {
+
+                // there is no property
+                if (!doc.has(parts[0])) {
+                    return null;
+                }
+
+                return getNested(doc.get(parts[0]), parts[1]);
+            }
+
+        } else if (obj instanceof JSONArray) {
+            JSONArray array = (JSONArray) obj;
+
+            if (!StringUtils.isNumeric(parts[0])) {
+                // this is not an integer, something is wrong
+                throw new JSONException("getNested: Unexpected non-int key");
+            }
+
+            int index = Integer.parseInt(parts[0]);
+            if (index < 0 || index > array.length()) {
+                return null; // out of range
+            }
+
+            if (parts[1].equals("")) {
+                return array.get(index);
+            } else {
+                return getNested(array.get(index), parts[1]);
+            }
+
+        } else {
+            throw new JSONException("getNested: Unexpected object");
+        }
+    }
+
+
+    private static void setNested(Object obj,
+                                  String key,
+                                  Object value)
+            throws JSONException {
+
+        String[] parts = splitKey(key);
+
+        if (obj instanceof JSONObject) {
+            JSONObject doc = (JSONObject) obj;
+
+            if (StringUtils.isNumeric(parts[0])) {
+                // this is a number, something is wrong
+                throw new JSONException("setNested: Unexpected numeric key");
+            }
+
+            if (parts[1].equals("")) {
+                doc.putOpt(key, value);
+            } else {
+
+                // there is no property
+                if (!doc.has(parts[0])) {
+                    String[] next = splitKey(parts[1]);
+                    if (StringUtils.isNumeric(next[0])) {
+                        // next part is an array
+                        doc.put(parts[0], new JSONArray());
+                    } else {
+                        doc.put(parts[0], new JSONObject());
+                    }
+                }
+
+                setNested(doc.get(parts[0]), parts[1], value);
+            }
+
+        } else if (obj instanceof JSONArray) {
+            JSONArray array = (JSONArray) obj;
+
+            if (!StringUtils.isNumeric(parts[0])) {
+                // this is not a number, something is wrong
+                throw new JSONException("setNested: Unexpected NaN key");
+            }
+
+            int index = Integer.parseInt(parts[0]);
+            if (index > array.length()) {
+                // fill array
+                array.put(index, JSONObject.NULL);
+            }
+
+            if (parts[1].equals("")) {
+                array.put(index, value);
+            } else {
+                setNested(array.get(index), parts[1], value);
+            }
+
+        } else {
+            throw new JSONException("setNested: Unexpected object");
+        }
+    }
+
+    private static String[] splitKey(String key) {
+
+        String[] split = {"", ""};
+        int point = key.indexOf('.');
+
+        if (point == -1) {
+            split[0] = key;
+        } else {
+            split[0] = key.substring(0, point);
+            split[1] = key.substring(point + 1);
+        }
+
+        return split;
+    }
+}

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/JSONUtils.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/JSONUtils.java
@@ -5,7 +5,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.Arrays;
 import java.util.Iterator;
 
 /**
@@ -123,14 +122,7 @@ public class JSONUtils {
     public static JSONObject flat(JSONObject doc, String[] keys)
             throws JSONException {
         JSONObject target = new JSONObject();
-        String[] allowedKeys;
-        if (keys == null) {
-            allowedKeys = new String[0];
-        } else {
-            allowedKeys = Arrays.copyOf(keys, keys.length);
-            Arrays.sort(allowedKeys);
-        }
-        flatting(target, doc, null, allowedKeys);
+        flatting(target, doc, null, keys);
         return target;
     }
 
@@ -228,6 +220,8 @@ public class JSONUtils {
                                  String[] allowedKeys)
             throws JSONException {
 
+        if (obj == null) return; // nothing to do
+
         if (obj instanceof JSONObject) {
             JSONObject doc = (JSONObject) obj;
 
@@ -252,9 +246,18 @@ public class JSONUtils {
 
         } else {
             // already flat
-            if (allowedKeys == null || allowedKeys.length == 0
-                    || Arrays.binarySearch(allowedKeys, prefix) != -1) {
+            // check allowed keys
+            if (allowedKeys == null || allowedKeys.length == 0) {
                 target.putOpt(prefix, obj);
+            } else {
+                // check if the prefix is in the allowed keys
+                for (String allowedKey : allowedKeys) {
+                    if (allowedKey.startsWith(prefix)) {
+                        // it's in the list
+                        target.putOpt(prefix, obj);
+                        break;
+                    }
+                }
             }
         }
     }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/Output.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/Output.java
@@ -8,7 +8,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-public interface OutputFactory {
+public interface Output {
 
     /**
      * Transform the searched documents into response body

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/Output.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/Output.java
@@ -16,17 +16,13 @@ public interface Output {
      * @param req,   request
      * @param resp,  response
      * @param docs,  searched JSON documents
-     * @param eTag,  entity tag
-     * @param debug, debug mode?
      * @return the body response
      * @throws IOException
      * @throws JSONException
      */
     public String getBody(final HttpServletRequest req,
                           final HttpServletResponse resp,
-                          final JSONArray docs,
-                          final String eTag,
-                          final boolean debug)
+                          final JSONArray docs)
             throws IOException, JSONException;
 
 }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
@@ -25,8 +25,10 @@ public class OutputDispatcher {
                 if (output.equals(format.toString())) {
                     // keys
                     String keysParam = req.getParameter(KEYS_PARAM);
-                    if (keysParam == null) keysParam = "";
-                    String[] keys = keysParam.split(",");
+                    String[] keys = null;
+                    if (keysParam != null && !keysParam.trim().equals("")) {
+                        keys = keysParam.split(",");
+                    }
 
                     // returns Formatted Documents Output
                     return new DocumentsOutputImpl(callback, debug, format, keys);

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
@@ -9,6 +9,7 @@ public class OutputDispatcher {
 
     private static final String OUTPUT_PARAM = "output_format";
     private static final String KEYS_PARAM = "export_keys";
+    private static final String CSV_PARAM = "csv_labels";
 
     public static Output getOutput(final HttpServletRequest req) {
 
@@ -26,12 +27,14 @@ public class OutputDispatcher {
                     // keys
                     String keysParam = req.getParameter(KEYS_PARAM);
                     String[] keys = null;
-                    if (keysParam != null && !keysParam.trim().equals("")) {
+                    if (keysParam != null && keysParam.trim().length() > 0) {
                         keys = keysParam.split(",");
                     }
+                    String labels = req.getParameter(CSV_PARAM);
 
                     // returns Formatted Documents Output
-                    return new DocumentsOutputImpl(callback, debug, format, keys);
+                    return new DocumentsOutputImpl(callback, debug,
+                            format, keys, labels);
                 }
             }
         }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
@@ -7,8 +7,8 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class OutputDispatcher {
 
-    private static final String OUTPUT_PARAM = "o";
-    private static final String KEYS_PARAM = "k";
+    private static final String OUTPUT_PARAM = "output_format";
+    private static final String KEYS_PARAM = "export_keys";
 
     public static Output getOutput(final HttpServletRequest req) {
 
@@ -19,15 +19,15 @@ public class OutputDispatcher {
         final String callback = req.getParameter("callback");
         final boolean debug = Boolean.parseBoolean(req.getParameter("debug"));
 
-        // keys
-        String keysParam = req.getParameter(KEYS_PARAM);
-        if (keysParam == null) keysParam = "";
-        String[] keys = keysParam.split(",");
-
         if (includeDocs && output != null) {
             // returns only formatted documents
             for (OutputFormats format : OutputFormats.values()) {
                 if (output.equals(format.toString())) {
+                    // keys
+                    String keysParam = req.getParameter(KEYS_PARAM);
+                    if (keysParam == null) keysParam = "";
+                    String[] keys = keysParam.split(",");
+
                     // returns Formatted Documents Output
                     return new DocumentsOutputImpl(callback, debug, format, keys);
                 }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
@@ -10,6 +10,7 @@ public class OutputDispatcher {
     private static final String OUTPUT_PARAM = "output_format";
     private static final String KEYS_PARAM = "export_keys";
     private static final String CSV_PARAM = "csv_labels";
+    private static final String DELIMITER_PARAM = "csv_delimiter";
 
     public static Output getOutput(final HttpServletRequest req) {
 
@@ -31,10 +32,11 @@ public class OutputDispatcher {
                         keys = keysParam.split(",");
                     }
                     String labels = req.getParameter(CSV_PARAM);
+                    String delimiter = req.getParameter(DELIMITER_PARAM);
 
                     // returns Formatted Documents Output
                     return new DocumentsOutputImpl(callback, debug,
-                            format, keys, labels);
+                            format, keys, labels, delimiter);
                 }
             }
         }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
@@ -1,0 +1,41 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Selects the Output class.
+ */
+public class OutputDispatcher {
+
+    private static final String OUTPUT_PARAM = "o";
+    private static final String KEYS_PARAM = "k";
+
+    public static Output getOutput(final HttpServletRequest req) {
+
+        // check the output parameter
+        String output = req.getParameter(OUTPUT_PARAM);
+        boolean includeDocs = Boolean.parseBoolean(
+                req.getParameter("include_docs"));
+        final String callback = req.getParameter("callback");
+        final boolean debug = Boolean.parseBoolean(req.getParameter("debug"));
+
+        // keys
+        String keysParam = req.getParameter(KEYS_PARAM);
+        if (keysParam == null) keysParam = "";
+        String[] keys = keysParam.split(",");
+
+        if (includeDocs && output != null) {
+            // returns only formatted documents
+            for (OutputFormats format : OutputFormats.values()) {
+                if (output.equals(format.toString())) {
+                    // returns Formatted Documents Output
+                    return new DocumentsOutputImpl(callback, debug, format, keys);
+                }
+            }
+        }
+
+        // default output response
+        return new DefaultOutputImpl(callback, debug);
+    }
+
+}

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputFactory.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputFactory.java
@@ -1,0 +1,32 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public interface OutputFactory {
+
+    /**
+     * Transform the searched documents into response body
+     *
+     * @param req,   request
+     * @param resp,  response
+     * @param docs,  searched JSON documents
+     * @param eTag,  entity tag
+     * @param debug, debug mode?
+     * @return the body response
+     * @throws IOException
+     * @throws JSONException
+     */
+    public String getBody(final HttpServletRequest req,
+                          final HttpServletResponse resp,
+                          final JSONArray docs,
+                          final String eTag,
+                          final boolean debug)
+            throws IOException, JSONException;
+
+}

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputFormats.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputFormats.java
@@ -32,22 +32,65 @@ public enum OutputFormats {
 
     /**
      * Transforms the given array of documents in the corresponding format
-     * mapped by the list of keys
      *
      * @param docs the array of documents
-     * @param keys the list of properties to be mapped
+     * @return the string expression of the formatted documents
+     * @throws JSONException
+     */
+    public String transformDocs(final JSONArray docs)
+            throws JSONException {
+        return transformDocs(docs, null, null);
+    }
+
+    /**
+     * Transforms the given array of documents in the corresponding format
+     * mapped by the list of keys
+     *
+     * @param docs   the array of documents
+     * @param keys   the list of properties to be mapped
+     * @param labels the list of columns for the CSV format
      * @return the string expression of the formatted documents
      * @throws JSONException
      */
     public String transformDocs(final JSONArray docs,
-                                final String[] keys)
+                                final String[] keys,
+                                final String labels)
             throws JSONException {
 
+        if (docs == null || docs.length() == 0) {
+            return ""; // nothing to export
+        }
+
         switch (this) {
+            case CSV:
+                // flatten documents
+                JSONArray flattenDocs = JSONUtils.flat(docs, keys);
+                // properties names
+                JSONArray names;
+                if (keys != null && keys.length > 0) {
+                    // use provided list
+                    names = new JSONArray(keys);
+                } else {
+                    // use first document properties
+                    names = flattenDocs.getJSONObject(0).names();
+                }
+
+                // decide first row
+                String firstRow;
+                if (labels != null && labels.trim().length() > 0) {
+                    // use labels as first row
+                    firstRow = labels;
+                } else {
+                    // use properties names as first row
+                    firstRow = names.join(",");
+                }
+
+                // create csv with documents and concatenate first row
+                return firstRow + "\n" + CDL.toString(names, flattenDocs);
+
             case XML:
                 return "<docs>" + org.json.XML.toString(docs, "doc") + "</docs>";
-            case CSV:
-                return CDL.toString(JSONUtils.flat(docs, keys));
+
             case JSON:
             default:
                 return docs.toString();

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputFormats.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputFormats.java
@@ -1,22 +1,56 @@
 package com.github.rnewson.couchdb.lucene.output;
 
+import org.json.CDL;
+import org.json.JSONArray;
+import org.json.JSONException;
+
 /**
  * Available output formats
  */
 public enum OutputFormats {
 
-    JSON("json"),
-    XML("xml"),
-    CSV("csv");
+    JSON("json", "application/json"),
+    XML("xml", "application/xml"),
+    CSV("csv", "text/plain");
 
-    private String value;
+    private String formatType;
+    private String contentType;
 
-    private OutputFormats(String value) {
-        this.value = value;
+    private OutputFormats(String type, String contentType) {
+        this.formatType = type;
+        this.contentType = contentType;
     }
 
     @Override
     public String toString() {
-        return this.value;
+        return this.formatType;
+    }
+
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    /**
+     * Transforms the given array of documents in the corresponding format
+     * mapped by the list of keys
+     *
+     * @param docs the array of documents
+     * @param keys the list of properties to be mapped
+     * @return the string expression of the formatted documents
+     * @throws JSONException
+     */
+    public String transformDocs(final JSONArray docs,
+                                final String[] keys)
+            throws JSONException {
+
+        switch (this) {
+            case XML:
+                return org.json.XML.toString(docs, "doc");
+            case CSV:
+                return CDL.toString(JSONUtils.flat(docs, keys));
+            case JSON:
+            default:
+                return docs.toString();
+        }
     }
 }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputFormats.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputFormats.java
@@ -1,0 +1,22 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+/**
+ * Available output formats
+ */
+public enum OutputFormats {
+
+    JSON("json"),
+    XML("xml"),
+    CSV("csv");
+
+    private String value;
+
+    private OutputFormats(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+}

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputFormats.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputFormats.java
@@ -45,7 +45,7 @@ public enum OutputFormats {
 
         switch (this) {
             case XML:
-                return org.json.XML.toString(docs, "doc");
+                return "<docs>" + org.json.XML.toString(docs, "doc") + "</docs>";
             case CSV:
                 return CDL.toString(JSONUtils.flat(docs, keys));
             case JSON:

--- a/src/test/java/com/github/rnewson/couchdb/lucene/output/JSONUtilsTest.java
+++ b/src/test/java/com/github/rnewson/couchdb/lucene/output/JSONUtilsTest.java
@@ -1,0 +1,142 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+/**
+ * Test JSONUtils methods
+ */
+public class JSONUtilsTest {
+
+    @Test
+    public void testGetDocs() throws Exception {
+        String input = "[{\"rows\":[" +
+                "{ \"doc\" : { \"a\" : 1, \"b\" : 1 } }," +
+                "{ \"doc\" : { \"a\" : 2, \"b\" : 2 } }," +
+                "{ \"doc\" : { \"a\" : 3, \"b\" : 3 } }," +
+                "{ \"doc\" : { \"a\" : 4, \"b\" : 4 } }" +
+                "]}]";
+        String output = "[" +
+                "{ \"a\" : 1 }," +
+                "{ \"a\" : 2 }," +
+                "{ \"a\" : 3 }," +
+                "{ \"a\" : 4 }" +
+                "]";
+        String[] keys = {"a"};
+
+        JSONArray docs = new JSONArray(input);
+        String expected = new JSONArray(output).toString();
+
+        String result = JSONUtils.getDocs(docs, keys).toString();
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void testFlatDocument() throws JSONException {
+        String input = "{ \"a\" : { \"b\" : 1 }," +
+                " \"c\" : [ 1, 2.5, 3 ], " +
+                "\"d\" : \"string\" }";
+        String output = "{ \"a.b\" : 1, " +
+                "\"c.0\" : 1, " +
+                "\"c.1\" : 2.5, " +
+                "\"c.2\" : 3, " +
+                "\"d\" : \"string\" }";
+
+        JSONObject doc = new JSONObject(input);
+        String expected = new JSONObject(output).toString();
+        String result = JSONUtils.flat(doc, null).toString();
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void testFlatDocuments() throws JSONException {
+        String input = "[{ \"a\" : { \"b\" : 1 }," +
+                " \"c\" : [ 1, 2.5, 3 ], " +
+                "\"d\" : \"string\" }]";
+        String output = "[{ \"a.b\" : 1, " +
+                "\"c.0\" : 1, " +
+                "\"c.1\" : 2.5, " +
+                "\"c.2\" : 3, " +
+                "\"d\" : \"string\" }]";
+
+        JSONArray docs = new JSONArray(input);
+        String expected = new JSONArray(output).toString();
+        String result = JSONUtils.flat(docs, null).toString();
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void testFlatDocumentsException() {
+        JSONArray input = new JSONArray();
+        input.put("a simple string");
+        input.put("other simple string");
+
+        Exception expected = null;
+        try {
+            JSONUtils.flat(input, null);
+        } catch (JSONException e) {
+            expected = e;
+        }
+
+        assertNotNull(expected);
+        assertThat(expected.getMessage(), is("Error flattening JSONArray."));
+    }
+
+    @Test
+    public void testMapDocument() throws JSONException {
+        String input = "{ \"a\" : { \"b\" : 1, \"g\": 1 }," +
+                " \"c\" : [ 1, 2, 3 ], " +
+                "\"d\" : \"string\" }";
+        String output = "{ \"a\" : { \"b\" : 1 }, " +
+                " \"c\" : [ null, 2 ], " +
+                "\"d\" : \"string\" }";
+        String[] names = {"a.b", "c.1", "d"};
+
+        JSONObject doc = new JSONObject(input);
+        String expected = new JSONObject(output).toString();
+        String result = JSONUtils.map(doc, names).toString();
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void testGetNestedProperty() throws JSONException {
+        String input = "{ \"a\" : { \"b\" : 1}," +
+                " \"c\" : [ 1, 2, 3 ], " +
+                "\"d\" : \"string\" }";
+        JSONObject doc = new JSONObject(input);
+
+        assertEquals(JSONUtils.getNestedProperty(doc, "a.b"), 1);
+        assertEquals(JSONUtils.getNestedProperty(doc, "c.2"), 3);
+        assertNull(JSONUtils.getNestedProperty(doc, "a.g"));
+        assertNull(JSONUtils.getNestedProperty(doc, "c.4"));
+    }
+
+    @Test
+    public void testSetNestedProperty() throws JSONException {
+        String input = "{ \"a\" : { \"b\" : 1}," +
+                " \"c\" :  [ 1, 2, 3 ], " +
+                "\"d\" : \"string\" }";
+        JSONObject doc = new JSONObject(input);
+
+        Integer value = 2;
+        JSONUtils.setNestedProperty(doc, "e.f", value);
+        JSONUtils.setNestedProperty(doc, "c.0", value);
+        JSONUtils.setNestedProperty(doc, "c.6", value);
+
+        assertEquals(JSONUtils.getNestedProperty(doc, "e.f"), value);
+        assertEquals(JSONUtils.getNestedProperty(doc, "c.0"), value);
+        assertEquals(JSONUtils.getNestedProperty(doc, "c.6"), value);
+        assertEquals(JSONUtils.getNestedProperty(doc, "c.3"), JSONObject.NULL);
+        assertEquals(JSONUtils.getNestedProperty(doc, "c.4"), JSONObject.NULL);
+        assertEquals(JSONUtils.getNestedProperty(doc, "c.5"), JSONObject.NULL);
+    }
+}

--- a/src/test/java/com/github/rnewson/couchdb/lucene/output/OutputFormatsTest.java
+++ b/src/test/java/com/github/rnewson/couchdb/lucene/output/OutputFormatsTest.java
@@ -39,10 +39,12 @@ public class OutputFormatsTest {
         OutputFormats format = OutputFormats.XML;
         String result = format.transformDocs(docs, null);
 
-        String expected = "<doc><baz>1</baz><bar><foo>1</foo></bar></doc>" +
+        String expected = "<docs>" +
+                "<doc><baz>1</baz><bar><foo>1</foo></bar></doc>" +
                 "<doc><baz>2</baz><bar><foo>2</foo></bar></doc>" +
                 "<doc><baz>3</baz><bar><foo>3</foo></bar></doc>" +
-                "<doc><baz>4</baz><bar><foo>4</foo></bar></doc>";
+                "<doc><baz>4</baz><bar><foo>4</foo></bar></doc>" +
+                "</docs>";
 
         // nothing change
         assertThat(result, is(expected));

--- a/src/test/java/com/github/rnewson/couchdb/lucene/output/OutputFormatsTest.java
+++ b/src/test/java/com/github/rnewson/couchdb/lucene/output/OutputFormatsTest.java
@@ -1,0 +1,77 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import org.json.JSONArray;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test OutputFormat enum
+ */
+public class OutputFormatsTest {
+
+    @Test
+    public void testJSONFormat() throws Exception {
+        JSONArray docs = getFixture();
+        OutputFormats format = OutputFormats.JSON;
+
+        String result = format.transformDocs(docs, null);
+
+        // nothing change
+        assertThat(result, is(docs.toString()));
+    }
+
+    @Test
+    public void testJSONFormatWithNames() throws Exception {
+        JSONArray docs = getFixture();
+        OutputFormats format = OutputFormats.JSON;
+
+        String result = format.transformDocs(docs, null);
+
+        // nothing change
+        assertThat(result, is(docs.toString()));
+    }
+
+    @Test
+    public void testXMLFormat() throws Exception {
+        JSONArray docs = getFixture();
+        OutputFormats format = OutputFormats.XML;
+        String result = format.transformDocs(docs, null);
+
+        String expected = "<doc><baz>1</baz><bar><foo>1</foo></bar></doc>" +
+                "<doc><baz>2</baz><bar><foo>2</foo></bar></doc>" +
+                "<doc><baz>3</baz><bar><foo>3</foo></bar></doc>" +
+                "<doc><baz>4</baz><bar><foo>4</foo></bar></doc>";
+
+        // nothing change
+        assertThat(result, is(expected));
+    }
+
+
+    @Test
+    public void testCSVFormat() throws Exception {
+        JSONArray docs = getFixture();
+        OutputFormats format = OutputFormats.CSV;
+        String result = format.transformDocs(docs, null);
+
+        String expected = "bar.foo,baz\n" +
+                "1,1\n" +
+                "2,2\n" +
+                "3,3\n" +
+                "4,4\n";
+
+        // nothing change
+        assertThat(result, is(expected));
+    }
+
+    private JSONArray getFixture() throws Exception {
+        String input = "[" +
+                "{ \"bar\" : { \"foo\" : 1 }, \"baz\" : 1 }," +
+                "{ \"bar\" : { \"foo\" : 2 }, \"baz\" : 2 }," +
+                "{ \"bar\" : { \"foo\" : 3 }, \"baz\" : 3 }," +
+                "{ \"bar\" : { \"foo\" : 4 }, \"baz\" : 4 }" +
+                "]";
+        return new JSONArray(input);
+    }
+}

--- a/src/test/java/com/github/rnewson/couchdb/lucene/output/OutputFormatsTest.java
+++ b/src/test/java/com/github/rnewson/couchdb/lucene/output/OutputFormatsTest.java
@@ -1,6 +1,7 @@
 package com.github.rnewson.couchdb.lucene.output;
 
 import org.json.JSONArray;
+import org.json.XML;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -16,18 +17,7 @@ public class OutputFormatsTest {
         JSONArray docs = getFixture();
         OutputFormats format = OutputFormats.JSON;
 
-        String result = format.transformDocs(docs, null);
-
-        // nothing change
-        assertThat(result, is(docs.toString()));
-    }
-
-    @Test
-    public void testJSONFormatWithNames() throws Exception {
-        JSONArray docs = getFixture();
-        OutputFormats format = OutputFormats.JSON;
-
-        String result = format.transformDocs(docs, null);
+        String result = format.transformDocs(docs);
 
         // nothing change
         assertThat(result, is(docs.toString()));
@@ -37,42 +27,58 @@ public class OutputFormatsTest {
     public void testXMLFormat() throws Exception {
         JSONArray docs = getFixture();
         OutputFormats format = OutputFormats.XML;
-        String result = format.transformDocs(docs, null);
+        String result = format.transformDocs(docs);
 
-        String expected = "<docs>" +
-                "<doc><baz>1</baz><bar><foo>1</foo></bar></doc>" +
-                "<doc><baz>2</baz><bar><foo>2</foo></bar></doc>" +
-                "<doc><baz>3</baz><bar><foo>3</foo></bar></doc>" +
-                "<doc><baz>4</baz><bar><foo>4</foo></bar></doc>" +
+        String output = "<docs>" +
+                "<doc><baz>11</baz><bar><foo>1</foo></bar></doc>" +
+                "<doc><baz>22</baz><bar><foo>2</foo></bar></doc>" +
+                "<doc><baz>33</baz><bar><foo>3</foo></bar></doc>" +
+                "<doc><baz>44</baz><bar><foo>4</foo></bar></doc>" +
                 "</docs>";
+        String expected = XML.toString(XML.toJSONObject(output));
 
-        // nothing change
         assertThat(result, is(expected));
     }
-
 
     @Test
     public void testCSVFormat() throws Exception {
         JSONArray docs = getFixture();
         OutputFormats format = OutputFormats.CSV;
-        String result = format.transformDocs(docs, null);
+        String[] keys = {"bar.foo", "baz"};
+        String result = format.transformDocs(docs, keys, null);
 
-        String expected = "bar.foo,baz\n" +
-                "1,1\n" +
-                "2,2\n" +
-                "3,3\n" +
-                "4,4\n";
+        String output = "\"bar.foo\",\"baz\"\n" +
+                "1,11\n" +
+                "2,22\n" +
+                "3,33\n" +
+                "4,44\n";
 
-        // nothing change
-        assertThat(result, is(expected));
+        assertThat(result, is(output));
+    }
+
+    @Test
+    public void testCSVFormatWithLabels() throws Exception {
+        JSONArray docs = getFixture();
+        OutputFormats format = OutputFormats.CSV;
+        String[] keys = {"bar.foo", "baz"};
+        String labels = "\"foo\",\"baz\"";
+        String result = format.transformDocs(docs, keys, labels);
+
+        String output = labels + "\n" +
+                "1,11\n" +
+                "2,22\n" +
+                "3,33\n" +
+                "4,44\n";
+
+        assertThat(result, is(output));
     }
 
     private JSONArray getFixture() throws Exception {
         String input = "[" +
-                "{ \"bar\" : { \"foo\" : 1 }, \"baz\" : 1 }," +
-                "{ \"bar\" : { \"foo\" : 2 }, \"baz\" : 2 }," +
-                "{ \"bar\" : { \"foo\" : 3 }, \"baz\" : 3 }," +
-                "{ \"bar\" : { \"foo\" : 4 }, \"baz\" : 4 }" +
+                "{ \"bar\" : { \"foo\" : 1 }, \"baz\" : 11 }," +
+                "{ \"bar\" : { \"foo\" : 2 }, \"baz\" : 22 }," +
+                "{ \"bar\" : { \"foo\" : 3 }, \"baz\" : 33 }," +
+                "{ \"bar\" : { \"foo\" : 4 }, \"baz\" : 44 }" +
                 "]";
         return new JSONArray(input);
     }

--- a/src/test/java/com/github/rnewson/couchdb/lucene/output/OutputFormatsTest.java
+++ b/src/test/java/com/github/rnewson/couchdb/lucene/output/OutputFormatsTest.java
@@ -45,13 +45,13 @@ public class OutputFormatsTest {
         JSONArray docs = getFixture();
         OutputFormats format = OutputFormats.CSV;
         String[] keys = {"bar.foo", "baz"};
-        String result = format.transformDocs(docs, keys, null);
+        String result = format.transformDocs(docs, keys, null, ";");
 
-        String output = "\"bar.foo\",\"baz\"\n" +
-                "1,11\n" +
-                "2,22\n" +
-                "3,33\n" +
-                "4,44\n";
+        String output = "\"bar.foo\";\"baz\"\n" +
+                "1;11\n" +
+                "2;22\n" +
+                "3;33\n" +
+                "4;44\n";
 
         assertThat(result, is(output));
     }
@@ -61,14 +61,14 @@ public class OutputFormatsTest {
         JSONArray docs = getFixture();
         OutputFormats format = OutputFormats.CSV;
         String[] keys = {"bar.foo", "baz"};
-        String labels = "\"foo\",\"baz\"";
-        String result = format.transformDocs(docs, keys, labels);
+        String labels = "\"foo\"\t\"baz\"";
+        String result = format.transformDocs(docs, keys, labels, "tab");
 
         String output = labels + "\n" +
-                "1,11\n" +
-                "2,22\n" +
-                "3,33\n" +
-                "4,44\n";
+                "1\t11\n" +
+                "2\t22\n" +
+                "3\t33\n" +
+                "4\t44\n";
 
         assertThat(result, is(output));
     }


### PR DESCRIPTION
Added new parameters:
- `output_format` the expected output format for the documents export. Allowed values: `json`, `xml`, `csv`.
  It's used to export only the documents; `include_docs` is needed; if it's false then this parameter has no effect.
- `export_keys` if `output_format` is present this parameter will indicate the document properties that will be exported.
- `csv_labels` if `output_format=csv` this parameter indicates the first row with the column headers. Otherwise will be ignored.
- `csv_delimiter` if `output_format=csv` this parameter indicates the character used to separate the values.

Example:
`curl -X GET https://auth@host:5984/database/_fti/_design/search-version:#.#.#/all?include_docs=true&stale=ok&q=search_chain&output_format=csv&export_keys=comma_separated_list_of_properties&csv_labels=comma_separated_csv_first_row&csv_delimiter=;`
