### PR TITLE
Export only the searched documents to CSV, XML or JSON.

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,16 @@ The following parameters can be passed for more sophisticated searches;
 <dt>skip</dt><dd>the number of results to skip</dd>
 <dt>sort</dt><dd>the comma-separated fields to sort on. Prefix with / for ascending order and \ for descending order (ascending is the default if not specified). Type-specific sorting is also available by appending the type between angle brackets (e.g, sort=amount&lt;float&gt;). Supported types are 'float', 'double', 'int', 'long' and 'date'.</dd>
 <dt>stale=ok</dt><dd>If you set the <i>stale</i> option to <i>ok</i>, couchdb-lucene will not block if the index is not up to date and it will immediately return results. Therefore searches may be faster as Lucene caches important data (especially for sorting). A query without stale=ok will block and use the latest data committed to the index. Unlike CouchDBs stale=ok option for views, couchdb-lucene will trigger an index update unless one is already running.</dd>
+<dt>output_format</dt><dd>the expected output format for the documents export.
+Allowed values: <i>json</i>, <i>xml</i>, <i>csv</i>.
+It's used to export only the documents; 'include_docs' is needed; if it's false
+this parameter has no effect.</dd>
+<dt>export_keys</dt><dd>if 'output_format' is present this parameter will
+indicate the document properties that will be exported.</dd>
+<dt>csv_labels</dt><dd>if 'output_format=csv' this parameter indicates the
+first row with the column headers. Otherwise will be ignored.</dd>
+<dt>csv_delimiter</dt><dd>if 'output_format=csv' this parameter indicates the
+character used to separate the values.</dd>
 </dl>
 
 <i>All parameters except 'q' are optional.</i>
@@ -502,6 +512,9 @@ The search result contains a number of fields at the top level, in addition to y
 <dt>skip</dt><dd>The number of initial matches that was skipped.</dd>
 <dt>total_rows</dt><dd>The total number of matches for this query.</dd>
 </dl>
+
+If the parameter 'output_format' is present; the results format will only
+contain the formatted and mapped <i>search results array</i>.
 
 <h2>The search results array</h2>
 

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/DefaultOutputImpl.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/DefaultOutputImpl.java
@@ -1,0 +1,47 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Default response
+ */
+public class DefaultOutputImpl implements Output {
+
+    private String callback;
+    private boolean debug;
+
+    public DefaultOutputImpl(String callback, boolean debug) {
+        this.callback = callback;
+        this.debug = debug;
+    }
+
+    @Override
+    public String getBody(HttpServletRequest req,
+                          HttpServletResponse resp,
+                          JSONArray docs)
+            throws IOException, JSONException {
+
+        final Object json = docs.length() > 1 ? docs : docs.getJSONObject(0);
+        final String body;
+
+        if (this.callback != null) {
+            body = String.format("%s(%s)", this.callback, json);
+        } else {
+            if (json instanceof JSONObject) {
+                final JSONObject obj = (JSONObject) json;
+                body = this.debug ? obj.toString(2) : obj.toString();
+            } else {
+                final JSONArray arr = (JSONArray) json;
+                body = this.debug ? arr.toString(2) : arr.toString();
+            }
+        }
+
+        return body;
+    }
+}

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/DocumentsOutputImpl.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/DocumentsOutputImpl.java
@@ -1,0 +1,56 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * JSON response
+ * <p>
+ * Transforms the JSON documents in other JSON documents
+ */
+public class DocumentsOutputImpl implements Output {
+
+    private OutputFormats format;
+    private String callback;
+    private boolean debug;
+    private String[] keys;
+    private String labels;
+    private String delimiter;
+
+    public DocumentsOutputImpl(String callback,
+                               boolean debug,
+                               OutputFormats format,
+                               String[] keys,
+                               String labels,
+                               String delimiter) {
+        this.callback = callback;
+        this.debug = debug;
+        this.format = format;
+        this.keys = keys;
+        this.labels = labels;
+        this.delimiter = delimiter;
+    }
+
+    @Override
+    public String getBody(HttpServletRequest req,
+                          HttpServletResponse resp,
+                          JSONArray docs)
+            throws IOException, JSONException {
+
+        final JSONArray json = JSONUtils.getDocs(docs, this.keys);
+
+        if (this.callback != null) {
+            return String.format("%s(%s)", this.callback, json);
+        } else {
+            resp.setContentType(this.format.getContentType());
+            return this.debug ?
+                    json.toString(2) :
+                    this.format.transformDocs(json, this.keys,
+                            this.labels, this.delimiter);
+        }
+    }
+}

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/JSONUtils.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/JSONUtils.java
@@ -1,0 +1,396 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import org.apache.commons.lang.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Iterator;
+
+/**
+ * Common methods
+ */
+public class JSONUtils {
+
+    /**
+     * Extracts from the `rows` property in the array the property `doc`
+     * <p>
+     * docs:
+     * [ { "rows" : [
+     * { "doc" : { "a" : 1, "b" : 1 } },
+     * { "doc" : { "a" : 2, "b" : 2 } }
+     * ] } ]
+     * keys:
+     * [ "a" ]
+     * <p>
+     * Returns:
+     * [ { "a" : 1 }, { "a" : 2 } ]
+     *
+     * @param docs, the searched documents
+     * @param keys, the properties to use, if empty all
+     * @return the array of `doc` property included in the rows array
+     */
+    public static JSONArray getDocs(JSONArray docs, String[] keys)
+            throws JSONException {
+
+        JSONArray result = new JSONArray();
+
+        for (int i = 0; i < docs.length(); i++) {
+            JSONArray rows = docs.getJSONObject(i).getJSONArray("rows");
+            if (rows != null) {
+                for (int j = 0; j < rows.length(); j++) {
+                    JSONObject doc = rows.getJSONObject(j).getJSONObject("doc");
+                    if (doc != null) {
+                        result.put(map(doc, keys));
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Maps document to the given list of properties
+     * <p>
+     * doc:
+     * { "a" : { "b" : 1, "c" : 2}, "d" : 4 }
+     * names:
+     * [ "a.b", "d" ]
+     * <p>
+     * Returns:
+     * { "a" { "b" : 1 }, "d" : 4 }
+     *
+     * @param doc  the document to be mapped
+     * @param keys the list of names for the new document
+     * @return the mapped document or the original document if names is empty
+     * @throws JSONException
+     */
+    public static JSONObject map(JSONObject doc, String[] keys)
+            throws JSONException {
+        if (keys == null || keys.length == 0) {
+            // nothing to map
+            return doc;
+        }
+
+        JSONObject target = new JSONObject();
+        mapping(target, doc, keys);
+        return target;
+    }
+
+    /**
+     * Maps documents with the given list of properties
+     *
+     * @param docs the array of documents
+     * @param keys the list of names for the new documents
+     * @return the array with mapped documents
+     * @throws JSONException
+     */
+    public static JSONArray map(JSONArray docs, String[] keys)
+            throws JSONException {
+
+        if (keys == null || keys.length == 0) {
+            // nothing to map
+            return docs;
+        }
+
+        // create new array with mapped documents
+        JSONArray array = new JSONArray();
+        for (int i = 0; i < docs.length(); i++) {
+            array.put(map(docs.getJSONObject(i), keys));
+        }
+
+        return array;
+    }
+
+    /**
+     * Flat the JSON document (no nested properties)
+     * <p>
+     * doc:
+     * { "a" : { "b" : 1 }, "c" : [ 1, 2, 3 ], "d" : 4 }
+     * keys:
+     * null
+     * <p>
+     * Returns:
+     * { "a.b" : 1, "c.0" : 1, "c.1" : 2, "c.2" : 3, "d" : 4 }
+     *
+     * @param doc   the document to be flattened
+     * @param keys, the properties to use, if empty all
+     * @return the flattened document
+     * @throws JSONException
+     */
+    public static JSONObject flat(JSONObject doc, String[] keys)
+            throws JSONException {
+        JSONObject target = new JSONObject();
+        flatting(target, doc, null, keys);
+        return target;
+    }
+
+    /**
+     * Flattens the array of JSON documents.
+     *
+     * @param array the array with the documents
+     * @param keys, the properties to use, if empty all
+     * @return an array with the flattened documents
+     * @throws JSONException if the arrays does not contain ALL JSON objects
+     */
+    public static JSONArray flat(JSONArray array, String[] keys)
+            throws JSONException {
+        JSONArray target = new JSONArray();
+        for (int i = 0; i < array.length(); i++) {
+            if (!(array.get(i) instanceof JSONObject)) {
+                throw new JSONException("Error flattening JSONArray.");
+            }
+            target.put(flat(array.getJSONObject(i), keys));
+        }
+        return target;
+    }
+
+    /**
+     * Get the value within a document
+     * <p>
+     * doc:
+     * { "a" : { "b" : 1 } }
+     * key:
+     * "a.b"
+     * <p>
+     * Returns:
+     * 1
+     * <p>
+     * doc: { "c" : [ 1, 2, 3 ] }
+     * key: "c.1"
+     * Returns:
+     * 2
+     *
+     * @param doc the document in which search
+     * @param key the property to search
+     * @return the property value
+     * @throws JSONException
+     */
+    public static Object getNestedProperty(JSONObject doc,
+                                           String key)
+            throws JSONException {
+
+        return getNested(doc, key);
+    }
+
+    /**
+     * Set the value within a document
+     * <p>
+     * doc: { "a" : { "b" : 1 } }
+     * key: "a.b"
+     * value: 2
+     * <p>
+     * Result:
+     * doc: { "a" : { "b" : 2 } }
+     * <p>
+     * doc: { "c" : [ 1, 2, 3 ] }
+     * key: "c.1"
+     * value: 9
+     * <p>
+     * Result:
+     * doc: { "c" : [ 1, 9, 3 ] }
+     *
+     * @param doc   the document in which search
+     * @param key   the property to search
+     * @param value the value to assign
+     * @throws JSONException
+     */
+    public static void setNestedProperty(JSONObject doc,
+                                         String key,
+                                         Object value)
+            throws JSONException {
+
+        setNested(doc, key, value);
+    }
+
+
+    private static void mapping(JSONObject target,
+                                JSONObject doc,
+                                String[] keys)
+            throws JSONException {
+        for (String key : keys) {
+            setNested(target, key, getNested(doc, key));
+        }
+    }
+
+    private static void flatting(JSONObject target,
+                                 Object obj,
+                                 String prefix,
+                                 String[] allowedKeys)
+            throws JSONException {
+
+        if (obj == null) return; // nothing to do
+
+        if (obj instanceof JSONObject) {
+            JSONObject doc = (JSONObject) obj;
+
+            Iterator<?> keys = doc.keys();
+            while (keys.hasNext()) {
+                String key = (String) keys.next();
+
+                flatting(target,
+                        doc.get(key),
+                        getKey(prefix, key),
+                        allowedKeys);
+            }
+        } else if (obj instanceof JSONArray) {
+            // array
+            JSONArray array = (JSONArray) obj;
+            for (int i = 0; i < array.length(); i++) {
+                flatting(target,
+                        array.get(i),
+                        getKey(prefix, Integer.toString(i, 10)),
+                        allowedKeys);
+            }
+
+        } else {
+            // already flat
+            // check allowed keys
+            if (allowedKeys == null || allowedKeys.length == 0) {
+                target.putOpt(prefix, obj);
+            } else {
+                // check if the prefix is in the allowed keys
+                for (String allowedKey : allowedKeys) {
+                    if (allowedKey.startsWith(prefix)) {
+                        // it's in the list
+                        target.putOpt(prefix, obj);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    private static String getKey(String prefix, String key) {
+        if (prefix == null) {
+            return key;
+        } else {
+            return prefix + "." + key;
+        }
+    }
+
+    private static Object getNested(Object obj,
+                                    String key)
+            throws JSONException {
+
+        String[] parts = splitKey(key);
+
+        if (obj instanceof JSONObject) {
+            JSONObject doc = (JSONObject) obj;
+
+            if (StringUtils.isNumeric(parts[0])) {
+                // this is not an array, something is wrong
+                throw new JSONException("getNested: Unexpected int key");
+            }
+
+            if (parts[1].equals("")) {
+                return doc.opt(key);
+            } else {
+
+                // there is no property
+                if (!doc.has(parts[0])) {
+                    return null;
+                }
+
+                return getNested(doc.get(parts[0]), parts[1]);
+            }
+
+        } else if (obj instanceof JSONArray) {
+            JSONArray array = (JSONArray) obj;
+
+            if (!StringUtils.isNumeric(parts[0])) {
+                // this is not an integer, something is wrong
+                throw new JSONException("getNested: Unexpected non-int key");
+            }
+
+            int index = Integer.parseInt(parts[0]);
+            if (index < 0 || index > array.length()) {
+                return null; // out of range
+            }
+
+            if (parts[1].equals("")) {
+                return array.get(index);
+            } else {
+                return getNested(array.get(index), parts[1]);
+            }
+
+        } else {
+            throw new JSONException("getNested: Unexpected object");
+        }
+    }
+
+
+    private static void setNested(Object obj,
+                                  String key,
+                                  Object value)
+            throws JSONException {
+
+        String[] parts = splitKey(key);
+
+        if (obj instanceof JSONObject) {
+            JSONObject doc = (JSONObject) obj;
+
+            if (StringUtils.isNumeric(parts[0])) {
+                // this is a number, something is wrong
+                throw new JSONException("setNested: Unexpected numeric key");
+            }
+
+            if (parts[1].equals("")) {
+                doc.putOpt(key, value);
+            } else {
+
+                // there is no property
+                if (!doc.has(parts[0])) {
+                    String[] next = splitKey(parts[1]);
+                    if (StringUtils.isNumeric(next[0])) {
+                        // next part is an array
+                        doc.put(parts[0], new JSONArray());
+                    } else {
+                        doc.put(parts[0], new JSONObject());
+                    }
+                }
+
+                setNested(doc.get(parts[0]), parts[1], value);
+            }
+
+        } else if (obj instanceof JSONArray) {
+            JSONArray array = (JSONArray) obj;
+
+            if (!StringUtils.isNumeric(parts[0])) {
+                // this is not a number, something is wrong
+                throw new JSONException("setNested: Unexpected NaN key");
+            }
+
+            int index = Integer.parseInt(parts[0]);
+            if (index > array.length()) {
+                // fill array
+                array.put(index, JSONObject.NULL);
+            }
+
+            if (parts[1].equals("")) {
+                array.put(index, value);
+            } else {
+                setNested(array.get(index), parts[1], value);
+            }
+
+        } else {
+            throw new JSONException("setNested: Unexpected object");
+        }
+    }
+
+    private static String[] splitKey(String key) {
+
+        String[] split = {"", ""};
+        int point = key.indexOf('.');
+
+        if (point == -1) {
+            split[0] = key;
+        } else {
+            split[0] = key.substring(0, point);
+            split[1] = key.substring(point + 1);
+        }
+
+        return split;
+    }
+}

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/Output.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/Output.java
@@ -1,0 +1,28 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public interface Output {
+
+    /**
+     * Transform the searched documents into response body
+     *
+     * @param req,  request
+     * @param resp, response
+     * @param docs, searched JSON documents
+     * @return the body response
+     * @throws IOException
+     * @throws JSONException
+     */
+    public String getBody(final HttpServletRequest req,
+                          final HttpServletResponse resp,
+                          final JSONArray docs)
+            throws IOException, JSONException;
+
+}

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
@@ -1,0 +1,48 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Selects the Output class.
+ */
+public class OutputDispatcher {
+
+    private static final String OUTPUT_PARAM = "output_format";
+    private static final String KEYS_PARAM = "export_keys";
+    private static final String CSV_PARAM = "csv_labels";
+    private static final String DELIMITER_PARAM = "csv_delimiter";
+
+    public static Output getOutput(final HttpServletRequest req) {
+
+        // check the output parameter
+        String output = req.getParameter(OUTPUT_PARAM);
+        boolean includeDocs = Boolean.parseBoolean(
+                req.getParameter("include_docs"));
+        final String callback = req.getParameter("callback");
+        final boolean debug = Boolean.parseBoolean(req.getParameter("debug"));
+
+        if (includeDocs && output != null) {
+            // returns only formatted documents
+            for (OutputFormats format : OutputFormats.values()) {
+                if (output.equals(format.toString())) {
+                    // keys
+                    String keysParam = req.getParameter(KEYS_PARAM);
+                    String[] keys = null;
+                    if (keysParam != null && keysParam.trim().length() > 0) {
+                        keys = keysParam.split(",");
+                    }
+                    String labels = req.getParameter(CSV_PARAM);
+                    String delimiter = req.getParameter(DELIMITER_PARAM);
+
+                    // returns Formatted Documents Output
+                    return new DocumentsOutputImpl(callback, debug,
+                            format, keys, labels, delimiter);
+                }
+            }
+        }
+
+        // default output response
+        return new DefaultOutputImpl(callback, debug);
+    }
+
+}

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputFormats.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputFormats.java
@@ -1,0 +1,114 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+/**
+ * Available output formats
+ */
+public enum OutputFormats {
+
+    JSON("json", "application/json"),
+    XML("xml", "application/xml"),
+    CSV("csv", "text/plain");
+
+    private String formatType;
+    private String contentType;
+
+    private OutputFormats(String type, String contentType) {
+        this.formatType = type;
+        this.contentType = contentType;
+    }
+
+    @Override
+    public String toString() {
+        return this.formatType;
+    }
+
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    /**
+     * Transforms the given array of documents in the corresponding format
+     *
+     * @param docs the array of documents
+     * @return the string expression of the formatted documents
+     * @throws JSONException
+     */
+    public String transformDocs(final JSONArray docs)
+            throws JSONException {
+        return transformDocs(docs, null, null, null);
+    }
+
+    /**
+     * Transforms the given array of documents in the corresponding format
+     * mapped by the list of keys
+     *
+     * @param docs      the array of documents
+     * @param keys      the list of properties to be mapped
+     * @param labels    the list of columns for the CSV format
+     * @param delimiter the delimiter char for the CSV format
+     * @return the string expression of the formatted documents
+     * @throws JSONException
+     */
+    public String transformDocs(final JSONArray docs,
+                                final String[] keys,
+                                final String labels,
+                                final String delimiter)
+            throws JSONException {
+
+        if (docs == null || docs.length() == 0) {
+            return ""; // nothing to export
+        }
+
+        switch (this) {
+            case CSV:
+                StringBuilder csv = new StringBuilder();
+                String join = ",";
+                if (delimiter != null && delimiter.length() == 1) {
+                    join = delimiter;
+                } else if (delimiter != null && delimiter.equals("tab")) {
+                    join = "\t";
+                }
+
+                // flatten documents
+                JSONArray flattenDocs = JSONUtils.flat(docs, keys);
+                // properties names
+                JSONArray names;
+                if (keys != null && keys.length > 0) {
+                    // use provided list
+                    names = new JSONArray(keys);
+                } else {
+                    // use first document properties
+                    names = flattenDocs.getJSONObject(0).names();
+                }
+
+                // decide first row
+                if (labels != null && labels.trim().length() > 0) {
+                    // use labels as first row
+                    csv.append(labels);
+                } else {
+                    // use properties names as first row
+                    csv.append(names.join(join));
+                }
+                csv.append("\n");
+
+                for (int i = 0; i < flattenDocs.length(); i++) {
+                    csv.append(flattenDocs
+                            .getJSONObject(i)
+                            .toJSONArray(names)
+                            .join(join));
+                    csv.append("\n");
+                }
+
+                return csv.toString();
+            case XML:
+                return "<docs>" + org.json.XML.toString(docs, "doc") + "</docs>";
+
+            case JSON:
+            default:
+                return docs.toString();
+        }
+    }
+}

--- a/src/test/java/com/github/rnewson/couchdb/lucene/output/JSONUtilsTest.java
+++ b/src/test/java/com/github/rnewson/couchdb/lucene/output/JSONUtilsTest.java
@@ -1,0 +1,142 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+/**
+ * Test JSONUtils methods
+ */
+public class JSONUtilsTest {
+
+    @Test
+    public void testGetDocs() throws Exception {
+        String input = "[{\"rows\":[" +
+                "{ \"doc\" : { \"a\" : 1, \"b\" : 1 } }," +
+                "{ \"doc\" : { \"a\" : 2, \"b\" : 2 } }," +
+                "{ \"doc\" : { \"a\" : 3, \"b\" : 3 } }," +
+                "{ \"doc\" : { \"a\" : 4, \"b\" : 4 } }" +
+                "]}]";
+        String output = "[" +
+                "{ \"a\" : 1 }," +
+                "{ \"a\" : 2 }," +
+                "{ \"a\" : 3 }," +
+                "{ \"a\" : 4 }" +
+                "]";
+        String[] keys = {"a"};
+
+        JSONArray docs = new JSONArray(input);
+        String expected = new JSONArray(output).toString();
+
+        String result = JSONUtils.getDocs(docs, keys).toString();
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void testFlatDocument() throws JSONException {
+        String input = "{ \"a\" : { \"b\" : 1 }," +
+                " \"c\" : [ 1, 2.5, 3 ], " +
+                "\"d\" : \"string\" }";
+        String output = "{ \"a.b\" : 1, " +
+                "\"c.0\" : 1, " +
+                "\"c.1\" : 2.5, " +
+                "\"c.2\" : 3, " +
+                "\"d\" : \"string\" }";
+
+        JSONObject doc = new JSONObject(input);
+        String expected = new JSONObject(output).toString();
+        String result = JSONUtils.flat(doc, null).toString();
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void testFlatDocuments() throws JSONException {
+        String input = "[{ \"a\" : { \"b\" : 1 }," +
+                " \"c\" : [ 1, 2.5, 3 ], " +
+                "\"d\" : \"string\" }]";
+        String output = "[{ \"a.b\" : 1, " +
+                "\"c.0\" : 1, " +
+                "\"c.1\" : 2.5, " +
+                "\"c.2\" : 3, " +
+                "\"d\" : \"string\" }]";
+
+        JSONArray docs = new JSONArray(input);
+        String expected = new JSONArray(output).toString();
+        String result = JSONUtils.flat(docs, null).toString();
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void testFlatDocumentsException() {
+        JSONArray input = new JSONArray();
+        input.put("a simple string");
+        input.put("other simple string");
+
+        Exception expected = null;
+        try {
+            JSONUtils.flat(input, null);
+        } catch (JSONException e) {
+            expected = e;
+        }
+
+        assertNotNull(expected);
+        assertThat(expected.getMessage(), is("Error flattening JSONArray."));
+    }
+
+    @Test
+    public void testMapDocument() throws JSONException {
+        String input = "{ \"a\" : { \"b\" : 1, \"g\": 1 }," +
+                " \"c\" : [ 1, 2, 3 ], " +
+                "\"d\" : \"string\" }";
+        String output = "{ \"a\" : { \"b\" : 1 }, " +
+                " \"c\" : [ null, 2 ], " +
+                "\"d\" : \"string\" }";
+        String[] names = {"a.b", "c.1", "d"};
+
+        JSONObject doc = new JSONObject(input);
+        String expected = new JSONObject(output).toString();
+        String result = JSONUtils.map(doc, names).toString();
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void testGetNestedProperty() throws JSONException {
+        String input = "{ \"a\" : { \"b\" : 1}," +
+                " \"c\" : [ 1, 2, 3 ], " +
+                "\"d\" : \"string\" }";
+        JSONObject doc = new JSONObject(input);
+
+        assertEquals(JSONUtils.getNestedProperty(doc, "a.b"), 1);
+        assertEquals(JSONUtils.getNestedProperty(doc, "c.2"), 3);
+        assertNull(JSONUtils.getNestedProperty(doc, "a.g"));
+        assertNull(JSONUtils.getNestedProperty(doc, "c.4"));
+    }
+
+    @Test
+    public void testSetNestedProperty() throws JSONException {
+        String input = "{ \"a\" : { \"b\" : 1}," +
+                " \"c\" :  [ 1, 2, 3 ], " +
+                "\"d\" : \"string\" }";
+        JSONObject doc = new JSONObject(input);
+
+        Integer value = 2;
+        JSONUtils.setNestedProperty(doc, "e.f", value);
+        JSONUtils.setNestedProperty(doc, "c.0", value);
+        JSONUtils.setNestedProperty(doc, "c.6", value);
+
+        assertEquals(JSONUtils.getNestedProperty(doc, "e.f"), value);
+        assertEquals(JSONUtils.getNestedProperty(doc, "c.0"), value);
+        assertEquals(JSONUtils.getNestedProperty(doc, "c.6"), value);
+        assertEquals(JSONUtils.getNestedProperty(doc, "c.3"), JSONObject.NULL);
+        assertEquals(JSONUtils.getNestedProperty(doc, "c.4"), JSONObject.NULL);
+        assertEquals(JSONUtils.getNestedProperty(doc, "c.5"), JSONObject.NULL);
+    }
+}

--- a/src/test/java/com/github/rnewson/couchdb/lucene/output/OutputFormatsTest.java
+++ b/src/test/java/com/github/rnewson/couchdb/lucene/output/OutputFormatsTest.java
@@ -1,0 +1,85 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import org.json.JSONArray;
+import org.json.XML;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test OutputFormat enum
+ */
+public class OutputFormatsTest {
+
+    @Test
+    public void testJSONFormat() throws Exception {
+        JSONArray docs = getFixture();
+        OutputFormats format = OutputFormats.JSON;
+
+        String result = format.transformDocs(docs);
+
+        // nothing change
+        assertThat(result, is(docs.toString()));
+    }
+
+    @Test
+    public void testXMLFormat() throws Exception {
+        JSONArray docs = getFixture();
+        OutputFormats format = OutputFormats.XML;
+        String result = format.transformDocs(docs);
+
+        String output = "<docs>" +
+                "<doc><baz>11</baz><bar><foo>1</foo></bar></doc>" +
+                "<doc><baz>22</baz><bar><foo>2</foo></bar></doc>" +
+                "<doc><baz>33</baz><bar><foo>3</foo></bar></doc>" +
+                "<doc><baz>44</baz><bar><foo>4</foo></bar></doc>" +
+                "</docs>";
+        String expected = XML.toString(XML.toJSONObject(output));
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void testCSVFormat() throws Exception {
+        JSONArray docs = getFixture();
+        OutputFormats format = OutputFormats.CSV;
+        String[] keys = {"bar.foo", "baz"};
+        String result = format.transformDocs(docs, keys, null, ";");
+
+        String output = "\"bar.foo\";\"baz\"\n" +
+                "1;11\n" +
+                "2;22\n" +
+                "3;33\n" +
+                "4;44\n";
+
+        assertThat(result, is(output));
+    }
+
+    @Test
+    public void testCSVFormatWithLabels() throws Exception {
+        JSONArray docs = getFixture();
+        OutputFormats format = OutputFormats.CSV;
+        String[] keys = {"bar.foo", "baz"};
+        String labels = "\"foo\"\t\"baz\"";
+        String result = format.transformDocs(docs, keys, labels, "tab");
+
+        String output = labels + "\n" +
+                "1\t11\n" +
+                "2\t22\n" +
+                "3\t33\n" +
+                "4\t44\n";
+
+        assertThat(result, is(output));
+    }
+
+    private JSONArray getFixture() throws Exception {
+        String input = "[" +
+                "{ \"bar\" : { \"foo\" : 1 }, \"baz\" : 11 }," +
+                "{ \"bar\" : { \"foo\" : 2 }, \"baz\" : 22 }," +
+                "{ \"bar\" : { \"foo\" : 3 }, \"baz\" : 33 }," +
+                "{ \"bar\" : { \"foo\" : 4 }, \"baz\" : 44 }" +
+                "]";
+        return new JSONArray(input);
+    }
+}


### PR DESCRIPTION
Added new parameters:
- `output_format` the expected output format for the documents export. Allowed values: `json`, `xml`, `csv`.
  It's used to export only the documents; `include_docs=true` is needed else this parameter has no effect.
- `export_keys` if `output_format` is present this parameter will indicate the document properties that will be exported.
- `csv_labels` if `output_format=csv` this parameter indicates the first row with the column headers. Otherwise will be ignored.
- `csv_delimiter` if `output_format=csv` this parameter indicates the character used to separate the values.

Example:
`curl -X GET https://auth@host:5984/database/_fti/_design/search-version:#.#.#/all?include_docs=true&stale=ok&q=search_chain&output_format=csv&export_keys=comma_separated_list_of_properties&csv_labels=comma_separated_csv_first_row&csv_delimiter=;`
