### PR TITLE
Parse plain document

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,10 @@ indicate the document properties that will be exported.</dd>
 first row with the column headers. Otherwise will be ignored.</dd>
 <dt>csv_delimiter</dt><dd>if 'output_format=csv' this parameter indicates the
 character used to separate the values.</dd>
+<dt>output_parser</dt><dd>if 'output_format' is present this parameter indicates
+the parser class name used to transform the searched documents before export.
+This class should be a subclass of
+<i>com.github.rnewson.couchdb.lucene.output.JSONParser</i></dd>
 </dl>
 
 <i>All parameters except 'q' are optional.</i>

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/DocumentsOutputImpl.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/DocumentsOutputImpl.java
@@ -20,19 +20,32 @@ public class DocumentsOutputImpl implements Output {
     private String[] keys;
     private String labels;
     private String delimiter;
+    private JSONParser parser;
 
     public DocumentsOutputImpl(String callback,
                                boolean debug,
                                OutputFormats format,
                                String[] keys,
                                String labels,
-                               String delimiter) {
+                               String delimiter,
+                               String parserClass) {
         this.callback = callback;
         this.debug = debug;
         this.format = format;
         this.keys = keys;
         this.labels = labels;
         this.delimiter = delimiter;
+        this.parser = new JSONParser();
+
+        if (parserClass != null && parserClass.length() > 0) {
+            // load parser class
+            try {
+                Class clazz = Class.forName(parserClass);
+                this.parser = (JSONParser) clazz.newInstance();
+            } catch (Exception e) {
+                // something went wrong, ignore parser
+            }
+        }
     }
 
     @Override
@@ -41,7 +54,7 @@ public class DocumentsOutputImpl implements Output {
                           JSONArray docs)
             throws IOException, JSONException {
 
-        final JSONArray json = JSONUtils.getDocs(docs, this.keys);
+        JSONArray json = JSONUtils.getDocs(docs, this.keys, this.parser);
 
         if (this.callback != null) {
             return String.format("%s(%s)", this.callback, json);

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/JSONParser.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/JSONParser.java
@@ -1,0 +1,20 @@
+package com.github.rnewson.couchdb.lucene.output;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Basic parser
+ */
+public class JSONParser {
+
+    /**
+     * Transforms the given json doc
+     *
+     * @param doc, the doc to be parsed
+     */
+    @SuppressWarnings("unused")
+    public void parse(JSONObject doc) throws JSONException {
+        // default, nothing to do
+    }
+}

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/JSONUtils.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/JSONUtils.java
@@ -26,11 +26,14 @@ public class JSONUtils {
      * Returns:
      * [ { "a" : 1 }, { "a" : 2 } ]
      *
-     * @param docs, the searched documents
-     * @param keys, the properties to use, if empty all
+     * @param docs   the searched documents
+     * @param keys   the properties to use, if empty all
+     * @param parser document parser, used to transform documents
      * @return the array of `doc` property included in the rows array
      */
-    public static JSONArray getDocs(JSONArray docs, String[] keys)
+    public static JSONArray getDocs(JSONArray docs,
+                                    String[] keys,
+                                    JSONParser parser)
             throws JSONException {
 
         JSONArray result = new JSONArray();
@@ -41,7 +44,7 @@ public class JSONUtils {
                 for (int j = 0; j < rows.length(); j++) {
                     JSONObject doc = rows.getJSONObject(j).getJSONObject("doc");
                     if (doc != null) {
-                        result.put(map(doc, keys));
+                        result.put(map(doc, keys, parser));
                     }
                 }
             }
@@ -61,12 +64,15 @@ public class JSONUtils {
      * Returns:
      * { "a" { "b" : 1 }, "d" : 4 }
      *
-     * @param doc  the document to be mapped
-     * @param keys the list of names for the new document
+     * @param doc    the document to be mapped
+     * @param keys   the list of names for the new document
+     * @param parser document parser
      * @return the mapped document or the original document if names is empty
      * @throws JSONException
      */
-    public static JSONObject map(JSONObject doc, String[] keys)
+    public static JSONObject map(JSONObject doc,
+                                 String[] keys,
+                                 JSONParser parser)
             throws JSONException {
         if (keys == null || keys.length == 0) {
             // nothing to map
@@ -74,19 +80,23 @@ public class JSONUtils {
         }
 
         JSONObject target = new JSONObject();
-        mapping(target, doc, keys);
+        mapping(target, doc, keys, parser);
         return target;
     }
 
     /**
      * Maps documents with the given list of properties
      *
-     * @param docs the array of documents
-     * @param keys the list of names for the new documents
+     * @param docs   the array of documents
+     * @param keys   the list of names for the new documents
+     * @param parser document parser
      * @return the array with mapped documents
      * @throws JSONException
      */
-    public static JSONArray map(JSONArray docs, String[] keys)
+    @SuppressWarnings("unused")
+    public static JSONArray map(JSONArray docs,
+                                String[] keys,
+                                JSONParser parser)
             throws JSONException {
 
         if (keys == null || keys.length == 0) {
@@ -97,7 +107,7 @@ public class JSONUtils {
         // create new array with mapped documents
         JSONArray array = new JSONArray();
         for (int i = 0; i < docs.length(); i++) {
-            array.put(map(docs.getJSONObject(i), keys));
+            array.put(map(docs.getJSONObject(i), keys, parser));
         }
 
         return array;
@@ -114,8 +124,8 @@ public class JSONUtils {
      * Returns:
      * { "a.b" : 1, "c.0" : 1, "c.1" : 2, "c.2" : 3, "d" : 4 }
      *
-     * @param doc   the document to be flattened
-     * @param keys, the properties to use, if empty all
+     * @param doc  the document to be flattened
+     * @param keys the properties to use, if empty all
      * @return the flattened document
      * @throws JSONException
      */
@@ -207,8 +217,12 @@ public class JSONUtils {
 
     private static void mapping(JSONObject target,
                                 JSONObject doc,
-                                String[] keys)
+                                String[] keys,
+                                JSONParser parser)
             throws JSONException {
+        if (parser != null) {
+            parser.parse(doc);
+        }
         for (String key : keys) {
             setNested(target, key, getNested(doc, key));
         }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/output/OutputDispatcher.java
@@ -11,6 +11,7 @@ public class OutputDispatcher {
     private static final String KEYS_PARAM = "export_keys";
     private static final String CSV_PARAM = "csv_labels";
     private static final String DELIMITER_PARAM = "csv_delimiter";
+    private static final String PARSER_PARAM = "output_parser";
 
     public static Output getOutput(final HttpServletRequest req) {
 
@@ -33,10 +34,11 @@ public class OutputDispatcher {
                     }
                     String labels = req.getParameter(CSV_PARAM);
                     String delimiter = req.getParameter(DELIMITER_PARAM);
+                    String parser = req.getParameter(PARSER_PARAM);
 
                     // returns Formatted Documents Output
                     return new DocumentsOutputImpl(callback, debug,
-                            format, keys, labels, delimiter);
+                            format, keys, labels, delimiter, parser);
                 }
             }
         }

--- a/src/test/java/com/github/rnewson/couchdb/lucene/output/JSONUtilsTest.java
+++ b/src/test/java/com/github/rnewson/couchdb/lucene/output/JSONUtilsTest.java
@@ -32,7 +32,7 @@ public class JSONUtilsTest {
         JSONArray docs = new JSONArray(input);
         String expected = new JSONArray(output).toString();
 
-        String result = JSONUtils.getDocs(docs, keys).toString();
+        String result = JSONUtils.getDocs(docs, keys, new JSONParser()).toString();
 
         assertThat(result, is(expected));
     }
@@ -102,7 +102,7 @@ public class JSONUtilsTest {
 
         JSONObject doc = new JSONObject(input);
         String expected = new JSONObject(output).toString();
-        String result = JSONUtils.map(doc, names).toString();
+        String result = JSONUtils.map(doc, names, new JSONParser()).toString();
 
         assertThat(result, is(expected));
     }


### PR DESCRIPTION
New parameter
- `output_parser` if `output_format` is present this parameter indicates the parser class name used to transform the searched documents before export.

Example: 

```
http://localhost:5984/gin_call_centre/_fti/_design/search-version:0.1.8/all?include_docs=true&stale=ok&output_format=csv&output_parser=org.ehealth.couchdb.parsers.CallCentreParser
```

In-house parsers will be included in other project, and added later as a dependency.
